### PR TITLE
add clojure.lang.PersistentVector encoding/decoding

### DIFF
--- a/src/main/clojure/clojure/data/fressian.clj
+++ b/src/main/clojure/clojure/data/fressian.clj
@@ -120,7 +120,14 @@
    {"sym"
     (reify WriteHandler
            (write [_ w s]
-                  (write-named "sym" w s)))}})
+                  (write-named "sym" w s)))}
+
+   clojure.lang.PersistentVector
+   {"vec"
+    (reify WriteHandler
+      (write [_ w s]
+             (.writeTag w "vec" 1)
+             (.writeList w s)))}})
 
 (defn field-caching-writer
   "Returns a record writer that caches values for keys
@@ -188,7 +195,10 @@
                             (let [kvs ^java.util.List (.readObject rdr)]
                               (if (< (.size kvs) 16)
                                 (clojure.lang.PersistentArrayMap. (.toArray kvs))
-                                (clojure.lang.PersistentHashMap/create (seq kvs))))))})
+                                (clojure.lang.PersistentHashMap/create (seq kvs))))))
+   "vec"
+   (reify ReadHandler (read [_ rdr tag component-count]
+                            (vec (.readObject rdr))))})
 
 (defn ^Writer create-writer
   "Create a fressian writer targeting out. Handlers must be

--- a/src/test/clojure/clojure/data/fressian_test.clj
+++ b/src/test/clojure/clojure/data/fressian_test.clj
@@ -44,6 +44,16 @@
   []
   (gen/rand-nth @keyword-pool))
 
+(def vector-pool
+  "Pool vectors so generation does not exhaust permgen"
+  (delay
+   (binding [gen/*rnd* (java.util.Random. 42)]
+     (into [] (repeatedly 1000 gen/vec)))))
+
+(defn vector-from-pool
+  []
+  (gen/rand-nth @vector-pool))
+
 (defrecord ExampleRecord [^long f1 ^char f2 f3])
 
 (defn gen-example-record
@@ -58,7 +68,8 @@
               gen/bigint
               gen-example-record
               symbol-from-pool
-              keyword-from-pool))
+              keyword-from-pool
+              vector-from-pool))
 
 (defspec test-roundtrip-anything
   roundtrip


### PR DESCRIPTION
Previously, `clojure.lang.PersistentVector` was not special-cased on writing
and reading. This resulted in fressian-encoded streams, containing Clojure
vectors, being coerced on reads into `java.lang.ArrayList`. Coercion here is
a bit surprising and potentially causes unexpected errors.

Here we explicitly mark `clojure.lang.PersistentVector` instances with the
`vec` tag on writes and upon reads decode these back to Clojure's vector type
by casting them with a call to `vec`.
